### PR TITLE
make the bots dance (#19) [backport: develop/v0.x]

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,3 +1,6 @@
 {
-  "prTitle": "{commitMessages} [{targetBranch}]"
+  "prTitle": "{commitMessages} [backport: {targetBranch}]",
+  "prDescription": "{defaultPrDescription}\n\n--- BEGIN COMMIT MESSAGE ---\nBackport to {targetBranch}\n{commitMessages}",
+  "sourcePRLabels": ["was-backported"],
+  "targetPRLabels": ["backport"]
 }

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -2,4 +2,6 @@ version = 1
 
 merge.message.title = "pull_request_title"
 merge.message.body = "pull_request_body"
+merge.message.cut_body_before = "--- BEGIN COMMIT MESSAGE ---"
+merge.message.cut_body_and_test = true
 merge.method = "squash"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `develop/v0.x`:
 - [make the bots dance (#19)](https://github.com/acts-project/backport-test/pull/19)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

--- BEGIN COMMIT MESSAGE ---
Backport to develop/v0.x
 - [make the bots dance (#19)](https://github.com/acts-project/backport-test/pull/19)