### PR TITLE
dance update (#22) [backport: develop/v0.x]

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,6 @@
 {
   "prTitle": "{commitMessages} [backport: {targetBranch}]",
-  "prDescription": "{defaultPrDescription}\n\n--- BEGIN COMMIT MESSAGE ---\nBackport to {targetBranch}\n{commitMessages}",
+  "prDescription": "{defaultPrDescription}\n\n--- BEGIN COMMIT MESSAGE ---\n\nBackport to {targetBranch}\n{commitMessages}",
   "sourcePRLabels": ["was-backported"],
   "targetPRLabels": ["backport"]
 }

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -3,5 +3,5 @@ version = 1
 merge.message.title = "pull_request_title"
 merge.message.body = "pull_request_body"
 merge.message.cut_body_before = "--- BEGIN COMMIT MESSAGE ---"
-merge.message.cut_body_and_test = true
+merge.message.cut_body_and_text = true
 merge.method = "squash"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `develop/v0.x`:
 - [dance update (#22)](https://github.com/acts-project/backport-test/pull/22)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

--- BEGIN COMMIT MESSAGE ---

Backport to develop/v0.x
 - [dance update (#22)](https://github.com/acts-project/backport-test/pull/22)